### PR TITLE
New LaserCan Sensors

### DIFF
--- a/src/main/kotlin/frc/team449/ControllerBindings.kt
+++ b/src/main/kotlin/frc/team449/ControllerBindings.kt
@@ -291,7 +291,8 @@ class ControllerBindings(
         .andThen(WaitCommand(0.25))
         .andThen(robot.intake.stop())
         .andThen(robot.superstructureManager.requestGoal(SuperstructureGoal.STOW))
-        .andThen(robot.intake.holdCoral()) )
+        .andThen(robot.intake.holdCoral())
+    )
   }
 
   private fun coralBlockSubstationIntake() {
@@ -331,7 +332,7 @@ class ControllerBindings(
                 .deadlineFor(robot.light.progressMaskGradient(percentageElevatorPosition))
                 .onlyIf { robot.superstructureManager.lastRequestedGoal() != SuperstructureGoal.L1 }
             ),
-          //dont have coral
+          // dont have coral
           ConditionalCommand( // have an algae
             robot.intake.outtakeAlgae()
               .andThen(WaitUntilCommand { !robot.intake.algaeDetected() })
@@ -342,7 +343,7 @@ class ControllerBindings(
                 robot.superstructureManager.requestGoal(SuperstructureGoal.STOW)
                   .deadlineFor(robot.light.progressMaskGradient(percentageElevatorPosition))
               ),
-            //dont have an algae
+            // dont have an algae
             robot.superstructureManager.requestGoal(SuperstructureGoal.GROUND_INTAKE)
               .alongWith(robot.intake.intakeCoral())
               .andThen(WaitUntilCommand { robot.intake.coralDetected() && RobotBase.isReal() })
@@ -518,18 +519,18 @@ class ControllerBindings(
     )
   }
 
-  private fun intakel1(){
-    Trigger{driveController.leftStick().asBoolean}.onTrue(
+  private fun intakel1() {
+    Trigger { driveController.leftStick().asBoolean }.onTrue(
       SequentialCommandGroup(
-      InstantCommand({robot.driveController.hid.setRumble(GenericHID.RumbleType.kBothRumble, 0.3)}),
+        InstantCommand({ robot.driveController.hid.setRumble(GenericHID.RumbleType.kBothRumble, 0.3) }),
         WaitCommand(0.5804),
-        InstantCommand({robot.driveController.hid.setRumble(GenericHID.RumbleType.kBothRumble, 0.0)})
-    )
+        InstantCommand({ robot.driveController.hid.setRumble(GenericHID.RumbleType.kBothRumble, 0.0) })
+      )
     ).toggleOnFalse(
       SequentialCommandGroup(
-        InstantCommand({robot.driveController.hid.setRumble(GenericHID.RumbleType.kBothRumble, 0.3)}),
+        InstantCommand({ robot.driveController.hid.setRumble(GenericHID.RumbleType.kBothRumble, 0.3) }),
         WaitCommand(0.5804),
-        InstantCommand({robot.driveController.hid.setRumble(GenericHID.RumbleType.kBothRumble, 0.0)})
+        InstantCommand({ robot.driveController.hid.setRumble(GenericHID.RumbleType.kBothRumble, 0.0) })
       )
     )
   }
@@ -724,5 +725,3 @@ class ControllerBindings(
     characterizationBindings()
   }
 }
-
-

--- a/src/main/kotlin/frc/team449/ControllerBindings.kt
+++ b/src/main/kotlin/frc/team449/ControllerBindings.kt
@@ -283,14 +283,16 @@ class ControllerBindings(
   }
 
   private fun groundIntakeHigh() {
-    //driveController.povUp().onTrue(
-      //robot.superstructureManager.requestGoal(SuperstructureGoal.GROUND_INTAKE_HIGH)
-        //.alongWith(robot.intake.intakeCoral())
-        //.andThen(WaitUntilCommand { robot.intake.coralDetected() && RobotBase.isReal() })
-        //.andThen(WaitCommand(0.25))
-        //.andThen(robot.intake.stop())
-        //.andThen(robot.superstructureManager.requestGoal(SuperstructureGoal.STOW))
-        //.andThen(robot.intake.holdCoral()) )
+    /*
+    driveController.povUp().onTrue(
+      robot.superstructureManager.requestGoal(SuperstructureGoal.GROUND_INTAKE_HIGH)
+        .alongWith(robot.intake.intakeCoral())
+        .andThen(WaitUntilCommand { robot.intake.coralDetected() && RobotBase.isReal() })
+        .andThen(WaitCommand(0.25))
+        .andThen(robot.intake.stop())
+        .andThen(robot.superstructureManager.requestGoal(SuperstructureGoal.STOW))
+        .andThen(robot.intake.holdCoral()) )
+    */
   }
 
   private fun coralBlockSubstationIntake() {

--- a/src/main/kotlin/frc/team449/ControllerBindings.kt
+++ b/src/main/kotlin/frc/team449/ControllerBindings.kt
@@ -332,7 +332,7 @@ class ControllerBindings(
                 .deadlineFor(robot.light.progressMaskGradient(percentageElevatorPosition))
                 .onlyIf { robot.superstructureManager.lastRequestedGoal() != SuperstructureGoal.L1 }
             ),
-          //dont have coral
+          // dont have coral
           ConditionalCommand( // have an algae
             robot.intake.outtakeAlgae()
               .andThen(WaitUntilCommand { !robot.intake.algaeDetected() })
@@ -343,7 +343,7 @@ class ControllerBindings(
                 robot.superstructureManager.requestGoal(SuperstructureGoal.STOW)
                   .deadlineFor(robot.light.progressMaskGradient(percentageElevatorPosition))
               ),
-            //dont have an algae
+            // dont have an algae
             robot.superstructureManager.requestGoal(SuperstructureGoal.GROUND_INTAKE)
               .alongWith(robot.intake.intakeCoral())
               .andThen(WaitUntilCommand { robot.intake.coralDetected() && RobotBase.isReal() })

--- a/src/main/kotlin/frc/team449/RobotLoop.kt
+++ b/src/main/kotlin/frc/team449/RobotLoop.kt
@@ -77,7 +77,7 @@ class RobotLoop : TimedRobot() {
     // Adds Auto Selection into Smart Dashboard
     SmartDashboard.putData("Auto Chooser", robot.autoChooser)
 
-    //While in Autonomous Period, run the selected auto until autos are over, then cancel command.
+    // While in Autonomous Period, run the selected auto until autos are over, then cancel command.
     RobotModeTriggers.autonomous().whileTrue(robot.autoChooser.selectedCommandScheduler())
     println("DONE Generating Auto Routines : ${Timer.getFPGATimestamp()}")
     SmartDashboard.putData("Command Scheduler", CommandScheduler.getInstance())
@@ -93,9 +93,8 @@ class RobotLoop : TimedRobot() {
     SmartDashboard.putData("Field", robot.field)
     SmartDashboard.putData("Elevator + Pivot Visual", robot.elevator.mech)
 
-    //This class reports data from REV devices
+    // This class reports data from REV devices
     URCL.start()
-
 
     QuadCalibration(robot.pivot, robot.pivot.absoluteEncoder, robot.pivot.quadEncoder, name = "Pivot")
       .ignoringDisable(true)

--- a/src/main/kotlin/frc/team449/subsystems/superstructure/BIT/BuiltInTests.kt
+++ b/src/main/kotlin/frc/team449/subsystems/superstructure/BIT/BuiltInTests.kt
@@ -188,13 +188,19 @@ class BuiltInTests(robot: Robot) {
         else -> wrist.setPosition(setpoint)
       },
       when (name) {
-        "pivot" -> checkVoltageWait({ pivot.atSetpoint(BITConstants.PIVOT_TOLERANCE) }, { pivot.getMotorVoltage() },
+        "pivot" -> checkVoltageWait(
+          { pivot.atSetpoint(BITConstants.PIVOT_TOLERANCE) },
+          { pivot.getMotorVoltage() },
           BITConstants.HIGH_PIVOT_VOLTAGE
         )
-        "elevator" -> checkVoltageWait({ elevator.atSetpoint(BITConstants.ELEVATOR_TOLERANCE) }, { elevator.getMotorVoltage() },
+        "elevator" -> checkVoltageWait(
+          { elevator.atSetpoint(BITConstants.ELEVATOR_TOLERANCE) },
+          { elevator.getMotorVoltage() },
           BITConstants.HIGH_ELEVATOR_VOLTAGE
         )
-        else -> checkVoltageWait({ wrist.atSetpoint(BITConstants.WRIST_TOLERANCE) }, { wrist.getMotorVoltage() },
+        else -> checkVoltageWait(
+          { wrist.atSetpoint(BITConstants.WRIST_TOLERANCE) },
+          { wrist.getMotorVoltage() },
           BITConstants.HIGH_WRIST_VOLTAGE
         )
       }

--- a/src/main/kotlin/frc/team449/subsystems/superstructure/SuperstructureGoal.kt
+++ b/src/main/kotlin/frc/team449/subsystems/superstructure/SuperstructureGoal.kt
@@ -106,7 +106,7 @@ object SuperstructureGoal {
     DriveDynamics(RobotConstants.MAX_LINEAR_SPEED, RobotConstants.MAX_ACCEL, RobotConstants.MAX_ROT_SPEED)
   )
 
-  //OLD L2 ALGAE DESCORE
+  // OLD L2 ALGAE DESCORE
   val L2_ALGAE_DESCORE = SuperstructureState(
     Degrees.of(42.188493899386),
     MIN_ELEVATOR_HEIGHT,
@@ -114,7 +114,7 @@ object SuperstructureGoal {
     DriveDynamics(RobotConstants.MAX_LINEAR_SPEED, RobotConstants.MAX_ACCEL, RobotConstants.MAX_ROT_SPEED)
   )
 
-  //OLD L3 ALGAE DESCORE
+  // OLD L3 ALGAE DESCORE
   val L3_ALGAE_DESCORE = SuperstructureState(
     Radians.of(0.958984),
     Meters.of(0.291016),
@@ -179,7 +179,7 @@ object SuperstructureGoal {
     DriveDynamics(RobotConstants.MAX_LINEAR_SPEED, RobotConstants.MAX_ACCEL, RobotConstants.MAX_ROT_SPEED)
   )
 
-  //TODO: FIND NET POSE
+  // TODO: FIND NET POSE
   val NET = SuperstructureState(
     L4.pivot,
     L4.elevator,
@@ -187,7 +187,7 @@ object SuperstructureGoal {
     DriveDynamics(RobotConstants.MAX_LINEAR_SPEED, RobotConstants.MAX_ACCEL, RobotConstants.MAX_ROT_SPEED)
   )
 
-  //TODO: FIND ALGAE GROUND INTAKE POSE
+  // TODO: FIND ALGAE GROUND INTAKE POSE
   val ALGAE_GROUND = SuperstructureState(
     Degrees.of(-5.15),
     Inches.of(-1.35),
@@ -195,7 +195,7 @@ object SuperstructureGoal {
     DriveDynamics(GROUND_INTAKE_SPEED, RobotConstants.MAX_ACCEL, RobotConstants.MAX_ROT_SPEED)
   )
 
-  //TODO: FIND ALGAE L2 INTAKE POSE
+  // TODO: FIND ALGAE L2 INTAKE POSE
   val L2_ALGAE_INTAKE = SuperstructureState(
     Degrees.of(-5.15),
     Inches.of(-1.35),
@@ -203,7 +203,7 @@ object SuperstructureGoal {
     DriveDynamics(GROUND_INTAKE_SPEED, RobotConstants.MAX_ACCEL, RobotConstants.MAX_ROT_SPEED)
   )
 
-  //TODO: FIND ALGAE L3 INTAKE POSE
+  // TODO: FIND ALGAE L3 INTAKE POSE
   val L3_ALGAE_INTAKE = SuperstructureState(
     Degrees.of(-5.15),
     Inches.of(-1.35),

--- a/src/main/kotlin/frc/team449/subsystems/superstructure/intake/Intake.kt
+++ b/src/main/kotlin/frc/team449/subsystems/superstructure/intake/Intake.kt
@@ -95,7 +95,7 @@ class Intake(
 
   // Coral is not vertical or horizontal but is detected by one of the sensors
   fun coralMisplaced(): Boolean {
-    return !coralVertical() && !coralHorizontal() && ( coralInfrared.get() || leftCoralInfrared.get() || rightCoralInfrared.get() || topCoralInfrared.get() )
+    return !coralVertical() && !coralHorizontal() && (coralInfrared.get() || leftCoralInfrared.get() || rightCoralInfrared.get() || topCoralInfrared.get())
   }
 
   fun algaeDetected(): Boolean {

--- a/src/main/kotlin/frc/team449/subsystems/superstructure/intake/Intake.kt
+++ b/src/main/kotlin/frc/team449/subsystems/superstructure/intake/Intake.kt
@@ -7,15 +7,17 @@ import edu.wpi.first.wpilibj2.command.Command
 import edu.wpi.first.wpilibj2.command.InstantCommand
 import edu.wpi.first.wpilibj2.command.SubsystemBase
 import frc.team449.system.motor.createSparkMax
-import au.grapplerobotics.LaserCan;
-import au.grapplerobotics.ConfigurationFailedException;
+import au.grapplerobotics.LaserCan
+import au.grapplerobotics.interfaces.LaserCanInterface
+import au.grapplerobotics.simulation.MockLaserCan
+import edu.wpi.first.wpilibj.RobotBase.isSimulation
 
 class Intake(
   private val motor: SparkMax,
-  private val bottomCoralSensor: LaserCan,
-  private val leftCoralSensor: LaserCan,
-  private val rightCoralSensor: LaserCan,
-  private val topCoralSensor: LaserCan
+  private val bottomCoralSensor: LaserCanInterface,
+  private val leftCoralSensor: LaserCanInterface,
+  private val rightCoralSensor: LaserCanInterface,
+  private val topCoralSensor: LaserCanInterface
 ) : SubsystemBase() {
 
   private val controller = PIDController(2.1778, 0.0, 0.010)
@@ -78,9 +80,9 @@ class Intake(
     return setVoltage(IntakeConstants.ALGAE_OUTTAKE_VOLTAGE)
   }
 
-  fun laserCanDetected(laserCan: LaserCan): Boolean {
-    val measurement: LaserCan.Measurement = laserCan.getMeasurement()
-    if (measurement != null && measurement.status == LaserCan.LASERCAN_STATUS_VALID_MEASUREMENT) {
+  fun laserCanDetected(laserCan: LaserCanInterface): Boolean {
+    val measurement: LaserCanInterface.Measurement = laserCan.measurement
+    if (measurement.status == LaserCan.LASERCAN_STATUS_VALID_MEASUREMENT) {
       if (measurement.distance_mm <= IntakeConstants.LASER_CAN_SENSOR_MIN_DISTANCE_MM) {
         return true
       }
@@ -127,10 +129,10 @@ class Intake(
   private fun logData() {
     DogLog.log("Intake/Motor Voltage", motor.appliedOutput * 12.0)
     DogLog.log("Intake/Motor Position", motor.encoder.position)
-    DogLog.log("Intake/Bottom Coral LaserCAN Distance (mm)", bottomCoralSensor.getMeasurement().distance_mm)
-    DogLog.log("Intake/Left Coral LaserCAN Distance (mm)", leftCoralSensor.getMeasurement().distance_mm)
-    DogLog.log("Intake/Right Coral LaserCAN Distance (mm)", rightCoralSensor.getMeasurement().distance_mm)
-    DogLog.log("Intake/Top Coral LaserCAN Distance (mm)", topCoralSensor.getMeasurement().distance_mm)
+    DogLog.log("Intake/Bottom Coral LaserCAN Distance (mm)", bottomCoralSensor.measurement.distance_mm.toDouble())
+    DogLog.log("Intake/Left Coral LaserCAN Distance (mm)", leftCoralSensor.measurement.distance_mm.toDouble())
+    DogLog.log("Intake/Right Coral LaserCAN Distance (mm)", rightCoralSensor.measurement.distance_mm.toDouble())
+    DogLog.log("Intake/Top Coral LaserCAN Distance (mm)", topCoralSensor.measurement.distance_mm.toDouble())
   }
 
   companion object {
@@ -142,11 +144,22 @@ class Intake(
         currentLimit = IntakeConstants.CURRENT_LIMIT
       )
 
-      val coralSensor = LaserCan(IntakeConstants.BOTTOM_CORAL_SENSOR_CAN_ID)
-      val leftCoralSensor = LaserCan(IntakeConstants.LEFT_CORAL_SENSOR_CAN_ID)
-      val rightCoralSensor = LaserCan(IntakeConstants.RIGHT_CORAL_SENSOR_CAN_ID)
-      val topCoralSensor = LaserCan(IntakeConstants.TOP_CORAL_SENSOR_CAN_ID)
-      return Intake(motor, coralSensor, leftCoralSensor, rightCoralSensor, topCoralSensor)
+      // Use MockLaserCan in Simulation
+      if (isSimulation()) {
+        return Intake(
+          motor,
+          MockLaserCan(),
+          MockLaserCan(),
+          MockLaserCan(),
+          MockLaserCan()
+        )
+      }
+      return Intake(motor,
+        LaserCan(IntakeConstants.BOTTOM_CORAL_SENSOR_CAN_ID),
+        LaserCan(IntakeConstants.LEFT_CORAL_SENSOR_CAN_ID),
+        LaserCan(IntakeConstants.RIGHT_CORAL_SENSOR_CAN_ID),
+        LaserCan(IntakeConstants.TOP_CORAL_SENSOR_CAN_ID)
+      )
     }
   }
 }

--- a/src/main/kotlin/frc/team449/subsystems/superstructure/intake/Intake.kt
+++ b/src/main/kotlin/frc/team449/subsystems/superstructure/intake/Intake.kt
@@ -1,16 +1,16 @@
 package frc.team449.subsystems.superstructure.intake
 
+import au.grapplerobotics.LaserCan
+import au.grapplerobotics.interfaces.LaserCanInterface
+import au.grapplerobotics.simulation.MockLaserCan
 import com.revrobotics.spark.SparkMax
 import dev.doglog.DogLog
 import edu.wpi.first.math.controller.PIDController
+import edu.wpi.first.wpilibj.RobotBase.isSimulation
 import edu.wpi.first.wpilibj2.command.Command
 import edu.wpi.first.wpilibj2.command.InstantCommand
 import edu.wpi.first.wpilibj2.command.SubsystemBase
 import frc.team449.system.motor.createSparkMax
-import au.grapplerobotics.LaserCan
-import au.grapplerobotics.interfaces.LaserCanInterface
-import au.grapplerobotics.simulation.MockLaserCan
-import edu.wpi.first.wpilibj.RobotBase.isSimulation
 
 class Intake(
   private val motor: SparkMax,
@@ -80,7 +80,7 @@ class Intake(
     return setVoltage(IntakeConstants.ALGAE_OUTTAKE_VOLTAGE)
   }
 
-  fun laserCanDetected(laserCan: LaserCanInterface): Boolean {
+  private fun laserCanDetected(laserCan: LaserCanInterface): Boolean {
     val measurement: LaserCanInterface.Measurement = laserCan.measurement
     if (measurement.status == LaserCan.LASERCAN_STATUS_VALID_MEASUREMENT) {
       if (measurement.distance_mm <= IntakeConstants.LASER_CAN_SENSOR_MIN_DISTANCE_MM) {
@@ -154,7 +154,8 @@ class Intake(
           MockLaserCan()
         )
       }
-      return Intake(motor,
+      return Intake(
+        motor,
         LaserCan(IntakeConstants.BOTTOM_CORAL_SENSOR_CAN_ID),
         LaserCan(IntakeConstants.LEFT_CORAL_SENSOR_CAN_ID),
         LaserCan(IntakeConstants.RIGHT_CORAL_SENSOR_CAN_ID),

--- a/src/main/kotlin/frc/team449/subsystems/superstructure/intake/Intake.kt
+++ b/src/main/kotlin/frc/team449/subsystems/superstructure/intake/Intake.kt
@@ -4,7 +4,6 @@ import com.revrobotics.spark.SparkMax
 import dev.doglog.DogLog
 import edu.wpi.first.math.controller.PIDController
 import edu.wpi.first.wpilibj.DigitalInput
-import edu.wpi.first.wpilibj.Timer
 import edu.wpi.first.wpilibj2.command.Command
 import edu.wpi.first.wpilibj2.command.InstantCommand
 import edu.wpi.first.wpilibj2.command.SubsystemBase
@@ -15,7 +14,7 @@ class Intake(
   private val coralInfrared: DigitalInput,
   private val leftCoralInfrared: DigitalInput,
   private val rightCoralInfrared: DigitalInput,
-  private val topCoralInfrared: DigitalInput,
+  private val topCoralInfrared: DigitalInput
 ) : SubsystemBase() {
 
   private val controller = PIDController(2.1778, 0.0, 0.010)
@@ -92,6 +91,11 @@ class Intake(
 
   fun coralHorizontal(): Boolean {
     return !coralInfrared.get() && !leftCoralInfrared.get() && !rightCoralInfrared.get()
+  }
+
+  // Coral is not vertical or horizontal but is detected by one of the sensors
+  fun coralMisplaced(): Boolean {
+    return !coralVertical() && !coralHorizontal() && ( coralInfrared.get() || leftCoralInfrared.get() || rightCoralInfrared.get() || topCoralInfrared.get() )
   }
 
   fun algaeDetected(): Boolean {

--- a/src/main/kotlin/frc/team449/subsystems/superstructure/intake/Intake.kt
+++ b/src/main/kotlin/frc/team449/subsystems/superstructure/intake/Intake.kt
@@ -13,6 +13,9 @@ import frc.team449.system.motor.createSparkMax
 class Intake(
   private val motor: SparkMax,
   private val coralInfrared: DigitalInput,
+  private val leftCoralInfrared: DigitalInput,
+  private val rightCoralInfrared: DigitalInput,
+  private val topCoralInfrared: DigitalInput,
 ) : SubsystemBase() {
 
   private val controller = PIDController(2.1778, 0.0, 0.010)
@@ -83,7 +86,16 @@ class Intake(
     return coralInfrared.get()
   }
 
+  fun coralVertical(): Boolean {
+    return !coralInfrared.get() && !topCoralInfrared.get()
+  }
+
+  fun coralHorizontal(): Boolean {
+    return !coralInfrared.get() && !leftCoralInfrared.get() && !rightCoralInfrared.get()
+  }
+
   fun algaeDetected(): Boolean {
+    // What is the point of this
     return false
   }
 
@@ -101,6 +113,9 @@ class Intake(
     DogLog.log("Intake/Motor Voltage", motor.appliedOutput * 12.0)
     DogLog.log("Intake/Motor Position", motor.encoder.position)
     DogLog.log("Intake/Coral IR sensor", !coralInfrared.get())
+    DogLog.log("Intake/Left Coral IR sensor", !leftCoralInfrared.get())
+    DogLog.log("Intake/Right Coral IR sensor", !rightCoralInfrared.get())
+    DogLog.log("Intake/Top Coral IR sensor", !topCoralInfrared.get())
   }
 
   companion object {
@@ -113,7 +128,10 @@ class Intake(
       )
 
       val coralSensor = DigitalInput(IntakeConstants.CORAL_SENSOR_DIO_PORT)
-      return Intake(motor, coralSensor)
+      val leftCoralSensor = DigitalInput(IntakeConstants.LEFT_CORAL_SENSOR_DIO_PORT)
+      val rightCoralSensor = DigitalInput(IntakeConstants.RIGHT_CORAL_SENSOR_DIO_PORT)
+      val topCoralSensor = DigitalInput(IntakeConstants.TOP_CORAL_SENSOR_DIO_PORT)
+      return Intake(motor, coralSensor, leftCoralSensor, rightCoralSensor, topCoralSensor)
     }
   }
 }

--- a/src/main/kotlin/frc/team449/subsystems/superstructure/intake/Intake.kt
+++ b/src/main/kotlin/frc/team449/subsystems/superstructure/intake/Intake.kt
@@ -106,13 +106,18 @@ class Intake(
     return laserCanDetected(bottomCoralSensor) && laserCanDetected(leftCoralSensor) && laserCanDetected(rightCoralSensor) && !laserCanDetected(topCoralSensor)
   }
 
+  // Coral is controlled by the Intake
+  fun coralControlled(): Boolean {
+    return coralVertical() || coralHorizontal()
+  }
+
   // Coral is not vertical or horizontal but is detected by one of the sensors
   fun coralMisplaced(): Boolean {
     return coralDetected() && !coralVertical() && !coralHorizontal()
   }
 
+  // What is the point of this
   fun algaeDetected(): Boolean {
-    // What is the point of this
     return false
   }
 
@@ -129,10 +134,10 @@ class Intake(
   private fun logData() {
     DogLog.log("Intake/Motor Voltage", motor.appliedOutput * 12.0)
     DogLog.log("Intake/Motor Position", motor.encoder.position)
-    DogLog.log("Intake/Bottom Coral LaserCAN Distance (mm)", bottomCoralSensor.measurement.distance_mm.toDouble())
-    DogLog.log("Intake/Left Coral LaserCAN Distance (mm)", leftCoralSensor.measurement.distance_mm.toDouble())
-    DogLog.log("Intake/Right Coral LaserCAN Distance (mm)", rightCoralSensor.measurement.distance_mm.toDouble())
-    DogLog.log("Intake/Top Coral LaserCAN Distance (mm)", topCoralSensor.measurement.distance_mm.toDouble())
+    DogLog.log("Intake/LaserCan/Bottom Sensor Distance (mm)", bottomCoralSensor.measurement.distance_mm.toDouble())
+    DogLog.log("Intake/LaserCan/Left Sensor Distance (mm)", leftCoralSensor.measurement.distance_mm.toDouble())
+    DogLog.log("Intake/LaserCan/Right Sensor Distance (mm)", rightCoralSensor.measurement.distance_mm.toDouble())
+    DogLog.log("Intake/LaserCan/Top Sensor Distance (mm)", topCoralSensor.measurement.distance_mm.toDouble())
   }
 
   companion object {

--- a/src/main/kotlin/frc/team449/subsystems/superstructure/intake/IntakeConstants.kt
+++ b/src/main/kotlin/frc/team449/subsystems/superstructure/intake/IntakeConstants.kt
@@ -32,4 +32,9 @@ object IntakeConstants {
   const val PIVOT_SENSOR_DIO_PORT = 12
 
   const val READY_PIVOT_CORAL_TIME = 0.25
+
+  // TODO Add DIO Ports for new sensors
+  const val LEFT_CORAL_SENSOR_DIO_PORT = 0
+  const val RIGHT_CORAL_SENSOR_DIO_PORT = 0
+  const val TOP_CORAL_SENSOR_DIO_PORT = 0
 }

--- a/src/main/kotlin/frc/team449/subsystems/superstructure/intake/IntakeConstants.kt
+++ b/src/main/kotlin/frc/team449/subsystems/superstructure/intake/IntakeConstants.kt
@@ -9,7 +9,6 @@ object IntakeConstants {
   val CURRENT_LIMIT: Current = Amps.of(30.0)
   const val BRAKE_MODE = true
 
-
   const val MOTOR_INVERTED = false
 
   const val CORAL_INTAKE_VOLTAGE = 11.0

--- a/src/main/kotlin/frc/team449/subsystems/superstructure/intake/IntakeConstants.kt
+++ b/src/main/kotlin/frc/team449/subsystems/superstructure/intake/IntakeConstants.kt
@@ -26,14 +26,17 @@ object IntakeConstants {
 
   const val WAIT_AFTER_ALGAE_DETECTED = 0.5
 
-  const val CORAL_SENSOR_DIO_PORT = 0
   const val ALGAE_SENSOR_DIO_PORT = 11
   const val PIVOT_SENSOR_DIO_PORT = 12
 
   const val READY_PIVOT_CORAL_TIME = 0.25
 
-  // TODO Add DIO Ports for new sensors
-  const val LEFT_CORAL_SENSOR_DIO_PORT = 20
-  const val RIGHT_CORAL_SENSOR_DIO_PORT = 21
-  const val TOP_CORAL_SENSOR_DIO_PORT = 22
+  // TODO Add CAN IDs for new LaserCAN sensors
+  const val TOP_CORAL_SENSOR_CAN_ID = 20
+  const val LEFT_CORAL_SENSOR_CAN_ID = 21
+  const val RIGHT_CORAL_SENSOR_CAN_ID = 22
+  const val TOP_CORAL_SENSOR_CAN_ID = 23
+
+  // Minimum distance in mm on the LaserCAN sensors to count as a detection (TODO Calibration)
+  const val LASER_CAN_SENSOR_MIN_DISTANCE_MM = 64
 }

--- a/src/main/kotlin/frc/team449/subsystems/superstructure/intake/IntakeConstants.kt
+++ b/src/main/kotlin/frc/team449/subsystems/superstructure/intake/IntakeConstants.kt
@@ -32,7 +32,7 @@ object IntakeConstants {
   const val READY_PIVOT_CORAL_TIME = 0.25
 
   // TODO Add CAN IDs for new LaserCAN sensors
-  const val TOP_CORAL_SENSOR_CAN_ID = 20
+  const val BOTTOM_CORAL_SENSOR_CAN_ID = 20
   const val LEFT_CORAL_SENSOR_CAN_ID = 21
   const val RIGHT_CORAL_SENSOR_CAN_ID = 22
   const val TOP_CORAL_SENSOR_CAN_ID = 23

--- a/src/main/kotlin/frc/team449/subsystems/superstructure/intake/IntakeConstants.kt
+++ b/src/main/kotlin/frc/team449/subsystems/superstructure/intake/IntakeConstants.kt
@@ -33,7 +33,7 @@ object IntakeConstants {
   const val READY_PIVOT_CORAL_TIME = 0.25
 
   // TODO Add DIO Ports for new sensors
-  const val LEFT_CORAL_SENSOR_DIO_PORT = 0
-  const val RIGHT_CORAL_SENSOR_DIO_PORT = 0
-  const val TOP_CORAL_SENSOR_DIO_PORT = 0
+  const val LEFT_CORAL_SENSOR_DIO_PORT = 20
+  const val RIGHT_CORAL_SENSOR_DIO_PORT = 21
+  const val TOP_CORAL_SENSOR_DIO_PORT = 22
 }

--- a/vendordeps/libgrapplefrc2024.json
+++ b/vendordeps/libgrapplefrc2024.json
@@ -1,0 +1,72 @@
+{
+    "fileName": "libgrapplefrc2024.json",
+    "name": "libgrapplefrc",
+    "version": "2024.3.1",
+    "frcYear": "2024",
+    "uuid": "8ef3423d-9532-4665-8339-206dae1d7168",
+    "mavenUrls": [ "https://storage.googleapis.com/grapple-frc-maven" ],
+    "jsonUrl": "https://storage.googleapis.com/grapple-frc-maven/libgrapplefrc2024.json",
+    "javaDependencies": [
+        {
+            "groupId": "au.grapplerobotics",
+            "artifactId": "libgrapplefrcjava",
+            "version": "2024.3.1"
+        }
+    ],
+    "jniDependencies": [
+        {
+            "groupId": "au.grapplerobotics",
+            "artifactId": "libgrapplefrcdriver",
+            "version": "2024.3.1",
+            "skipInvalidPlatforms": true,
+            "isJar": false,
+            "validPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        }
+    ],
+    "cppDependencies": [
+        {
+            "groupId": "au.grapplerobotics",
+            "artifactId": "libgrapplefrccpp",
+            "version": "2024.3.1",
+            "libName": "grapplefrc",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        },
+        {
+            "groupId": "au.grapplerobotics",
+            "artifactId": "libgrapplefrcdriver",
+            "version": "2024.3.1",
+            "libName": "grapplefrcdriver",
+            "headerClassifier": "headers",
+            "sharedLibrary": true,
+            "skipInvalidPlatforms": true,
+            "binaryPlatforms": [
+                "windowsx86-64",
+                "windowsx86",
+                "linuxarm64",
+                "linuxx86-64",
+                "linuxathena",
+                "linuxarm32",
+                "osxuniversal"
+            ]
+        }
+    ]
+}

--- a/vendordeps/libgrapplefrc2025.json
+++ b/vendordeps/libgrapplefrc2025.json
@@ -1,23 +1,25 @@
 {
-    "fileName": "libgrapplefrc2024.json",
+    "fileName": "libgrapplefrc2025.json",
     "name": "libgrapplefrc",
-    "version": "2024.3.1",
-    "frcYear": "2024",
+    "version": "2025.1.3",
+    "frcYear": "2025",
     "uuid": "8ef3423d-9532-4665-8339-206dae1d7168",
-    "mavenUrls": [ "https://storage.googleapis.com/grapple-frc-maven" ],
-    "jsonUrl": "https://storage.googleapis.com/grapple-frc-maven/libgrapplefrc2024.json",
+    "mavenUrls": [
+        "https://storage.googleapis.com/grapple-frc-maven"
+    ],
+    "jsonUrl": "https://storage.googleapis.com/grapple-frc-maven/libgrapplefrc2025.json",
     "javaDependencies": [
         {
             "groupId": "au.grapplerobotics",
             "artifactId": "libgrapplefrcjava",
-            "version": "2024.3.1"
+            "version": "2025.1.3"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "au.grapplerobotics",
             "artifactId": "libgrapplefrcdriver",
-            "version": "2024.3.1",
+            "version": "2025.1.3",
             "skipInvalidPlatforms": true,
             "isJar": false,
             "validPlatforms": [
@@ -35,7 +37,7 @@
         {
             "groupId": "au.grapplerobotics",
             "artifactId": "libgrapplefrccpp",
-            "version": "2024.3.1",
+            "version": "2025.1.3",
             "libName": "grapplefrc",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -53,7 +55,7 @@
         {
             "groupId": "au.grapplerobotics",
             "artifactId": "libgrapplefrcdriver",
-            "version": "2024.3.1",
+            "version": "2025.1.3",
             "libName": "grapplefrcdriver",
             "headerClassifier": "headers",
             "sharedLibrary": true,


### PR DESCRIPTION
Added LaserCan Sensors from libgrapplefrc to the Intake Subsystem

Simulation:
- Works in sim
- Uses `MockLaserCan` class when in simulation

New Functions:
- `coralVertical(): Boolean`
  - For L2, L3, and L4 Scoring
- `coralHorizontal(): Boolean`
  - For L1 Scoring
- `coralControlled(): Boolean`
  - Coral is either vertical or horizontal
- `coralMisplaced(): Boolean`
  - Coral is detected but not vertical or horizontal

New Constants:
- Sensor CAN IDs:
  - `BOTTOM_CORAL_SENSOR_CAN_ID`
  - `LEFT_CORAL_SENSOR_CAN_ID`
  - `RIGHT_CORAL_SENSOR_CAN_ID`
  - `TOP_CORAL_SENSOR_CAN_ID`
- `LASER_CAN_SENSOR_MIN_DISTANCE_MM`
  - Minimum distance for the LaserCan Sensor to detect Coral
  - Currently set to 64mm